### PR TITLE
Stock: 重构股票数据结构，添加国内外期货支持；移除调试信息日志

### DIFF
--- a/Plugins/Stock/DataManager.cpp
+++ b/Plugins/Stock/DataManager.cpp
@@ -180,7 +180,7 @@ void CDataManager::RequestRealtimeData()
 
     url += CCommon::vectorJoinString(params, L"&");
     CString strHeaders = _T("Referer: https://finance.sina.com.cn");
-    CCommon::WriteLog(url.c_str(), g_data.m_log_path.c_str());
+    // CCommon::WriteLog(url.c_str(), g_data.m_log_path.c_str());
 
     std::string Stock_data;
     if (CCommon::GetURL(url, Stock_data, false, WEB_USERAGENT, strHeaders, strHeaders.GetLength()))
@@ -203,7 +203,7 @@ void CDataManager::RequestTimelineData(std::wstring stock_id)
         params.push_back(L"dpc=1");
 
         url += CCommon::vectorJoinString(params, L"&");
-        CCommon::WriteLog(url.c_str(), g_data.m_log_path.c_str());
+        // CCommon::WriteLog(url.c_str(), g_data.m_log_path.c_str());
 
         // CString strHeaders = L"Referer: https://finance.sina.com.cn/realstock/company/" + m_stock_id + L"/nc.shtml";
         std::wstring strHeaders{L"Referer: https://finance.sina.com.cn/realstock/company/"};

--- a/Plugins/Stock/FloatingWnd.cpp
+++ b/Plugins/Stock/FloatingWnd.cpp
@@ -216,12 +216,12 @@ void CFloatingWnd::OnPaint()
     CPen pKLine(PS_SOLID, 1, RGB(70, 113, 152));
     memDC.SelectObject(&pKLine);
 
-    STOCK::RealTimeData realtimeData;
+    STOCK::StockInfo realtimeData;
     std::vector<STOCK::TimelinePoint> timelinePoint;
     {
         std::lock_guard<std::mutex> lock(Stock::Instance().m_stockDataMutex);
         auto stockData = g_data.GetStockData(m_stock_id);
-        realtimeData = stockData->realTimeData;
+        realtimeData = stockData->info;
         timelinePoint = stockData->getTimelineData()->data;
     }
 

--- a/Plugins/Stock/Stock.h
+++ b/Plugins/Stock/Stock.h
@@ -13,6 +13,8 @@ constexpr auto kSZ = L"sz";    // 深圳
 constexpr auto kHK = L"rt_hk"; // 香港
 constexpr auto kMG = L"gb_";   // 美国
 constexpr auto kBJ = L"bj";    // 北京
+constexpr auto kNF = L"nf";    // 国内期货
+constexpr auto kHF = L"hf";    // 海外期货
 
 const std::vector<CString> StockTypeSet{kSH, kSZ, kHK, kMG, kBJ};
 

--- a/Plugins/Stock/StockDef.cpp
+++ b/Plugins/Stock/StockDef.cpp
@@ -18,6 +18,10 @@ constexpr auto _DATA_LEN_SZ = 33;
 constexpr auto _DATA_LEN_BJ = 39;
 // 港股数据长度
 constexpr auto _DATA_LEN_HK = 25;
+// 国内期货数据长度
+constexpr auto _DATA_LEN_NF = 16;
+// 海外期货数据长度
+constexpr auto _DATA_LEN_HF = 14;
 
 using namespace STOCK;
 
@@ -98,6 +102,14 @@ void STOCK::StockInfo::Load(std::wstring key, std::vector<std::string> data_arr)
   else if (key.find(kHK) == 0)
   {
     LoadHK(data_arr, data_size);
+  }
+  else if (key.find(kNF) == 0)
+  {
+    LoadNF(data_arr, data_size);
+  }
+  else if (key.find(kHF) == 0)
+  {
+    LoadHF(data_arr, data_size);
   }
 
   if (currentPrice > 0 && prevClosePrice > 0)
@@ -198,6 +210,66 @@ void STOCK::StockInfo::LoadHK(std::vector<std::string> data, size_t size)
   lowPrice = {convert<Price>(data[5])};
   volume = {convert<Volume>(data[12])};
   turnover = {convert<Price>(data[11])};
+}
+
+void STOCK::StockInfo::LoadNF(std::vector<std::string> data, size_t size)
+{
+    if (size < _DATA_LEN_NF)
+    {
+        return;
+	}
+    /* 解析格式，与股票略有不同
+    var hq_str_V2201="PVC2201,230000,
+    8585.00, 8692.00, 8467.00, 8641.00, // params[2,3,4,5] 开，高，低，昨收
+    8673.00, 8674.00, // params[6, 7] 买一、卖一价
+    8675.00, // 现价 params[8]
+    8630.00, // 均价
+    8821.00, // 昨日结算价【一般软件的行情涨跌幅按这个价格显示涨跌幅】（后续考虑配置项，设置按收盘价还是结算价显示涨跌幅）
+    109, // 买一量
+    2, // 卖一量
+    289274, // 持仓量
+    230643, //总量
+    连, // params[8 + 7] 交易所名称 ["连","沪", "郑"]
+    PVC,2021-11-26,1,9243.000,8611.000,9243.000,8251.000,9435.000,8108.000,13380.000,8108.000,445.541";
+    */
+	displayName = CCommon::StrToUnicode(data[0].c_str());
+	openPrice = { convert<Price>(data[2]) };
+	highPrice = { convert<Price>(data[3]) };
+	lowPrice = { convert<Price>(data[4]) };
+	prevClosePrice = { convert<Price>(data[10]) };  // 昨结算
+	currentPrice = { convert<Price>(data[8]) };
+	volume = { convert<Volume>(data[14]) };
+}
+
+void STOCK::StockInfo::LoadHF(std::vector<std::string> data, size_t size)
+{
+    if (size < _DATA_LEN_HF)
+    {
+		return;
+	}
+    // 海外期货格式
+    // 0 当前价格
+    // '105.306', '',
+    //  2  买一价  3 卖一价  4  最高价   5 最低价
+    // '105.270', '105.290', '105.540', '102.950',
+    //  6 时间   7 昨日结算价  8 开盘价  9 持仓量
+    // '15:51:34', '102.410', '103.500', '250168.000',
+    // 10 买 11 卖 12 日期      13 名称  14 成交量
+    // '5', '2', '2022-05-04', 'WTI纽约原油2206', '28346'
+	currentPrice = { convert<Price>(data[0]) };
+	highPrice = { convert<Price>(data[4]) };
+	lowPrice = { convert<Price>(data[5]) };
+	prevClosePrice = { convert<Price>(data[7]) };
+	openPrice = { convert<Price>(data[8]) };
+	displayName = CCommon::StrToUnicode(data[13].c_str());
+    // The overseas futures name field (data[13]) may contain additional information in parentheses,
+    // e.g. "伦敦金（现货黄金）". To keep the display name concise and consistent with other formats,
+    // we strip any characters after '（', retaining only the main contract name.
+    displayName = displayName.substr(0, displayName.find(L"（"));
+
+	
+	if (data.size() >= 15)
+        volume = { convert<Volume>(data[14]) };
 }
 
 void STOCK::StockMarket::LoadTimelineDataByJson(std::wstring stock_id, CString *pData)

--- a/Plugins/Stock/StockDef.cpp
+++ b/Plugins/Stock/StockDef.cpp
@@ -69,13 +69,13 @@ void STOCK::StockMarket::LoadRealtimeDataByJson(std::string json)
 
     std::vector<std::string> data_arr = CCommon::split(data, ",");
 
-    stockData->info.displayName = CCommon::StrToUnicode(data_arr[0].c_str());
+    // stockData->info.displayName = CCommon::StrToUnicode(data_arr[0].c_str());
 
-    stockData->realTimeData.Load(key, data_arr);
+    stockData->info.Load(key, data_arr);
   }
 }
 
-void STOCK::RealTimeData::Load(std::wstring key, std::vector<std::string> data_arr)
+void STOCK::StockInfo::Load(std::wstring key, std::vector<std::string> data_arr)
 {
   size_t data_size = static_cast<size_t>(data_arr.size());
 
@@ -111,12 +111,13 @@ void STOCK::RealTimeData::Load(std::wstring key, std::vector<std::string> data_a
   }
 }
 
-void STOCK::RealTimeData::LoadMG(std::vector<std::string> data, size_t size)
+void STOCK::StockInfo::LoadMG(std::vector<std::string> data, size_t size)
 {
   if (size < _DATA_LEN_MG)
   {
     return;
   }
+  displayName = CCommon::StrToUnicode(data[0].c_str());
   openPrice = {convert<Price>(data[5])};
   prevClosePrice = {convert<Price>(data[26])};
   currentPrice = {convert<Price>(data[1])};
@@ -126,8 +127,9 @@ void STOCK::RealTimeData::LoadMG(std::vector<std::string> data, size_t size)
   // turnover = {convert<Price>(data[5])};
 }
 
-void STOCK::RealTimeData::LoadAG(std::vector<std::string> data, size_t size)
+void STOCK::StockInfo::LoadAG(std::vector<std::string> data, size_t size)
 {
+  displayName = CCommon::StrToUnicode(data[0].c_str());
   openPrice = {convert<Price>(data[1])};
   prevClosePrice = {convert<Price>(data[2])};
   currentPrice = {convert<Price>(data[3])};
@@ -155,7 +157,7 @@ void STOCK::RealTimeData::LoadAG(std::vector<std::string> data, size_t size)
   bidLevels[4] = {{convert<Price>(data[19])}, {convert<Volume>(data[18])}};
 }
 
-void STOCK::RealTimeData::LoadSH(std::vector<std::string> data, size_t size)
+void STOCK::StockInfo::LoadSH(std::vector<std::string> data, size_t size)
 {
   if (size < _DATA_LEN_SH)
   {
@@ -164,7 +166,7 @@ void STOCK::RealTimeData::LoadSH(std::vector<std::string> data, size_t size)
   LoadAG(data, size);
 }
 
-void STOCK::RealTimeData::LoadSZ(std::vector<std::string> data, size_t size)
+void STOCK::StockInfo::LoadSZ(std::vector<std::string> data, size_t size)
 {
   if (size < _DATA_LEN_SZ)
   {
@@ -173,7 +175,7 @@ void STOCK::RealTimeData::LoadSZ(std::vector<std::string> data, size_t size)
   LoadAG(data, size);
 }
 
-void STOCK::RealTimeData::LoadBJ(std::vector<std::string> data, size_t size)
+void STOCK::StockInfo::LoadBJ(std::vector<std::string> data, size_t size)
 {
   if (size < _DATA_LEN_BJ)
   {
@@ -182,12 +184,13 @@ void STOCK::RealTimeData::LoadBJ(std::vector<std::string> data, size_t size)
   LoadAG(data, size);
 }
 
-void STOCK::RealTimeData::LoadHK(std::vector<std::string> data, size_t size)
+void STOCK::StockInfo::LoadHK(std::vector<std::string> data, size_t size)
 {
   if (size < _DATA_LEN_HK)
   {
     return;
   }
+  displayName = CCommon::StrToUnicode(data[0].c_str());
   openPrice = {convert<Price>(data[2])};
   prevClosePrice = {convert<Price>(data[3])};
   currentPrice = {convert<Price>(data[6])};
@@ -218,7 +221,7 @@ std::wstring STOCK::StockData::GetCurrentDisplay(bool include_name) const
   {
     if (include_name)
       wss << info.displayName << ": ";
-    wss << realTimeData.displayPrice << ' ' << realTimeData.displayFluctuation;
+    wss << info.displayPrice << ' ' << info.displayFluctuation;
   }
   else
   {

--- a/Plugins/Stock/StockDef.h
+++ b/Plugins/Stock/StockDef.h
@@ -201,6 +201,8 @@ namespace STOCK
     void LoadSZ(std::vector<std::string> data, size_t size);
     void LoadBJ(std::vector<std::string> data, size_t size);
     void LoadHK(std::vector<std::string> data, size_t size);
+    void LoadNF(std::vector<std::string> data, size_t size);
+    void LoadHF(std::vector<std::string> data, size_t size);
   };
 
   // 股票数据结构

--- a/Plugins/Stock/StockDef.h
+++ b/Plugins/Stock/StockDef.h
@@ -29,48 +29,50 @@ namespace STOCK
   };
 
   // 最新交易数据
-  struct RealTimeData
-  {
-    Price openPrice;      // 今日开盘价
-    Price prevClosePrice; // 昨日收盘价
-    Price currentPrice;   // 当前价格
-    Price highPrice;      // 最高价
-    Price lowPrice;       // 最低价
-    Volume volume;        // 成交量(股)
-    Amount turnover;      // 成交额(元)
+ // struct RealTimeData
+ // {
+ //   Price openPrice;      // 今日开盘价
+ //   Price prevClosePrice; // 昨日收盘价
+ //   Price currentPrice;   // 当前价格
+ //   Price highPrice;      // 最高价
+ //   Price lowPrice;       // 最低价
+ //   Volume volume;        // 成交量(股)
+ //   Amount turnover;      // 成交额(元)
 
-    std::wstring displayPrice = L"--";
-    std::wstring displayFluctuation = L"--%";
+ //   std::wstring displayPrice = L"--";
+ //   std::wstring displayFluctuation = L"--%";
 
-    Price priceLimit; // 价格限制
+ //   Price priceLimit; // 价格限制
 
-    // 买卖盘口，使用数组便于遍历
-    static const int MAX_LEVEL = 5;
+ //   // 买卖盘口，使用数组便于遍历
+ //   static const int MAX_LEVEL = 5;
 
-    OrderLevel askLevels[MAX_LEVEL]; // 卖盘(5档)
-    OrderLevel bidLevels[MAX_LEVEL]; // 买盘(5档)
+ //   OrderLevel askLevels[MAX_LEVEL]; // 卖盘(5档)
+ //   OrderLevel bidLevels[MAX_LEVEL]; // 买盘(5档)
 
-    RealTimeData() : openPrice(0.0),
-                     prevClosePrice(0.0),
-                     currentPrice(0.0),
-                     highPrice(0.0),
-                     lowPrice(0.0),
-                     volume(0),
-                     turnover(0.0),
-                     priceLimit(0.0)
-    {
-      // bidLevels.resize(MAX_LEVEL);
-      // askLevels.resize(MAX_LEVEL);
-    }
+ //   RealTimeData() : openPrice(0.0),
+ //                    prevClosePrice(0.0),
+ //                    currentPrice(0.0),
+ //                    highPrice(0.0),
+ //                    lowPrice(0.0),
+ //                    volume(0),
+ //                    turnover(0.0),
+ //                    priceLimit(0.0)
+ //   {
+ //     // bidLevels.resize(MAX_LEVEL);
+ //     // askLevels.resize(MAX_LEVEL);
+ //   }
 
-    void Load(std::wstring key, std::vector<std::string> data);
-    void LoadMG(std::vector<std::string> data, size_t size);
-    void LoadAG(std::vector<std::string> data, size_t size);
-    void LoadSH(std::vector<std::string> data, size_t size);
-    void LoadSZ(std::vector<std::string> data, size_t size);
-    void LoadBJ(std::vector<std::string> data, size_t size);
-    void LoadHK(std::vector<std::string> data, size_t size);
-  };
+ //   void Load(std::wstring key, std::vector<std::string> data);
+ //   void LoadMG(std::vector<std::string> data, size_t size);
+ //   void LoadAG(std::vector<std::string> data, size_t size);
+ //   void LoadSH(std::vector<std::string> data, size_t size);
+ //   void LoadSZ(std::vector<std::string> data, size_t size);
+ //   void LoadBJ(std::vector<std::string> data, size_t size);
+ //   void LoadHK(std::vector<std::string> data, size_t size);
+ //   void LoadNF(std::vector<std::string> data, size_t size);
+ //   void LoadHF(std::vector<std::string> data, size_t size);
+ // };
 
   // 分时数据点
   struct TimelinePoint
@@ -159,14 +161,54 @@ namespace STOCK
 
     bool is_ok = TRUE;              // 加载成功标志
     // std::string industry; // 所属行业
+
+    Price openPrice;      // 今日开盘价
+    Price prevClosePrice; // 昨日收盘价
+    Price currentPrice;   // 当前价格
+    Price highPrice;      // 最高价
+    Price lowPrice;       // 最低价
+    Volume volume;        // 成交量(股)
+    Amount turnover;      // 成交额(元)
+
+    std::wstring displayPrice = L"--";
+    std::wstring displayFluctuation = L"--%";
+
+    Price priceLimit; // 价格限制
+
+    // 买卖盘口，使用数组便于遍历
+    static const int MAX_LEVEL = 5;
+
+    OrderLevel askLevels[MAX_LEVEL]; // 卖盘(5档)
+    OrderLevel bidLevels[MAX_LEVEL]; // 买盘(5档)
+
+    StockInfo() : openPrice(0.0),
+        prevClosePrice(0.0),
+        currentPrice(0.0),
+        highPrice(0.0),
+        lowPrice(0.0),
+        volume(0),
+        turnover(0.0),
+        priceLimit(0.0)
+    {
+        // bidLevels.resize(MAX_LEVEL);
+        // askLevels.resize(MAX_LEVEL);
+    }
+
+    void Load(std::wstring key, std::vector<std::string> data);
+    void LoadMG(std::vector<std::string> data, size_t size);
+    void LoadAG(std::vector<std::string> data, size_t size);
+    void LoadSH(std::vector<std::string> data, size_t size);
+    void LoadSZ(std::vector<std::string> data, size_t size);
+    void LoadBJ(std::vector<std::string> data, size_t size);
+    void LoadHK(std::vector<std::string> data, size_t size);
   };
 
   // 股票数据结构
   class StockData
   {
   public:
-    StockInfo info;            // 基础信息
-    RealTimeData realTimeData; // 最新数据
+    StockInfo info;
+    // RealTimeData realTimeData; // 最新数据
 
     std::wstring GetCurrentDisplay(bool include_name = true) const;
 
@@ -226,8 +268,8 @@ namespace STOCK
     {
       for (const auto &it : stocks)
       {
-        RealTimeData data;
-        it.second->realTimeData = data;
+        StockInfo data;
+        it.second->info = data;
       }
     }
 
@@ -252,12 +294,12 @@ namespace STOCK
     }
 
     // 更新股票最新数据
-    void updateStockData(const std::wstring &code, const RealTimeData &data)
+    void updateStockData(const std::wstring &code, const StockInfo &data)
     {
       auto stock = getStock(code);
       if (stock)
       {
-        stock->realTimeData = data;
+        stock->info = data;
       }
     }
 

--- a/Plugins/Stock/StockItem.cpp
+++ b/Plugins/Stock/StockItem.cpp
@@ -109,7 +109,7 @@ void StockItem::DrawItem(void *hDC, int x, int y, int w, int h, bool dark_mode)
     if (g_data.m_setting_data.m_color_with_price)
     {
         // 绘制数值
-        if (data->realTimeData.displayFluctuation.find('-') != std::wstring::npos)
+        if (data->info.displayFluctuation.find('-') != std::wstring::npos)
             pDC->SetTextColor(color_green);
         else
             pDC->SetTextColor(color_red);

--- a/Plugins/Stock/StockItem.cpp
+++ b/Plugins/Stock/StockItem.cpp
@@ -61,7 +61,7 @@ int StockItem::GetItemWidthEx(void *hDC) const
     char buff[32];
     sprintf_s(buff, "GetItemWidthEx %d", width);
 
-    CCommon::WriteLog(CCommon::StrToUnicode(buff).c_str(), g_data.m_log_path.c_str());
+    // CCommon::WriteLog(CCommon::StrToUnicode(buff).c_str(), g_data.m_log_path.c_str());
     LogX(L"GetItemWidthEx: %d\n", width);
     return width;
 }


### PR DESCRIPTION
改动共分为两个部分：

1. 添加期货支持。原有的股票数据结构将股票信息拆分成了两部分：基础信息和实时数据，爬取新浪接口数据后发现，并非所有的代码返回值都将“显示名称”放在第一个数据位，因此该拆分是不必要且错误的，所有的数据都应该从接口中动态的加载，而非用写死的型式从第一个数据位取名字。
2. 移除大量无用的调试日志。插件文件夹下，正常使用一天时间就会产生十几兆大小的日志文件，内容全都是无意义的某次请求数据所使用的url和窗口大小调整信息，该类信息明显为调试信息，不应该出现在正式版中向用户终端塞入大量垃圾，故移除